### PR TITLE
Scale bullets based on player size

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -50,8 +50,17 @@ class MainScene extends Phaser.Scene {
     }
 
     if (Phaser.Input.Keyboard.JustDown(this.cursors.space)) {
-      const bullet = this.bullets.create(this.player.x, this.player.y - 20, 'bullet');
+      const bullet = this.bullets.create(
+        this.player.x,
+        this.player.y - 20,
+        'bullet'
+      );
       bullet.setVelocityY(-300);
+
+      const bWidth = this.player.displayWidth * 0.3;
+      const bHeight = this.player.displayHeight * 0.3;
+      bullet.setDisplaySize(bWidth, bHeight);
+      bullet.body.setSize(bWidth, bHeight);
     }
   }
 }


### PR DESCRIPTION
## Summary
- size bullets to 30% of the player so visuals and physics match

## Testing
- `node -v` *(fails: command not found)*